### PR TITLE
adds tests and updates for dealing with better event-emitters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,4 @@ script:
   - npm run gen:coverage
 
 after_success:
-  - npm run pub:coverage
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then npm run pub:coverage; fi

--- a/bootstrap/app.js
+++ b/bootstrap/app.js
@@ -15,7 +15,7 @@
  */
 
 require('kraeve');
-const { rootDir, SystemConfig } = require('regent/bootstrap/system-config');
+const { SystemConfig } = require('regent/bootstrap/system-config');
 
 const AppConfig = require(SystemConfig.AppConfig.file);
 const Regent    = require('regent/lib/core/regent');
@@ -30,7 +30,7 @@ const Regent    = require('regent/lib/core/regent');
  | low-level routing and function of Regent's HTTP and Console kernels.
  |
  */
-const app = new Regent(rootDir, SystemConfig, AppConfig);
+const app = new Regent(SystemConfig, AppConfig);
 
 /*
  |------------------------------------------------------------------------------

--- a/bootstrap/directories.js
+++ b/bootstrap/directories.js
@@ -6,19 +6,19 @@
 const path = require('path');
 
 class Directories {
-    static configure(rootPath, config) {
-        createResolve(rootPath, config, Directories);
-        createRequire(rootPath, config, Directories);
-        createReload(rootPath, config, Directories);
+    static configure(config) {
+        createResolve(config, Directories);
+        createRequire(config, Directories);
+        createReload(config, Directories);
     }
 }
 
-function createResolve(rootPath, config, parent) {
-    const resolve = (src = '') => {
-        return path.resolve(rootPath, src);
+function createResolve(config, parent) {
+    const resolveFactory = (base) => {
+        return (src = '') => path.resolve(path.join(base, src));
     };
 
-    parent.resolve = resolve;
+    parent.resolve = resolveFactory('');
 
     /**
      * Resolve a path to the base Pub folder
@@ -27,7 +27,7 @@ function createResolve(rootPath, config, parent) {
      *
      * @return {String}
      */
-    parent.resolvePub = (src = '') => resolve(path.join(config.pub, src));
+    parent.resolvePub = resolveFactory(config.pub);
 
     /**
      * Resolve a path to the base config folder
@@ -36,7 +36,7 @@ function createResolve(rootPath, config, parent) {
      *
      * @return {String}
      */
-    parent.resolveEtc = (src = '') => resolve(path.join(config.etc, src));
+    parent.resolveEtc = resolveFactory(config.etc);
 
     /**
      * Resolve a path to the base lib folder
@@ -45,7 +45,7 @@ function createResolve(rootPath, config, parent) {
      *
      * @return {String}
      */
-    parent.resolveLib = (src = '') => resolve(path.join(config.lib, src));
+    parent.resolveLib = resolveFactory(config.lib);
 
     /**
      * Resolve a path to the session folder
@@ -54,9 +54,7 @@ function createResolve(rootPath, config, parent) {
      *
      * @return {String}
      */
-    parent.resolveSession = (src = '') => {
-        return resolve(path.join(config.session, src));
-    };
+    parent.resolveSession = resolveFactory(config.session);
 
     /**
      * Resolve a path to the base view folder
@@ -65,10 +63,10 @@ function createResolve(rootPath, config, parent) {
      *
      * @return {String}
      */
-    parent.resolveView = (src = '') => resolve(path.join(config.view, src));
+    parent.resolveView = resolveFactory(config.view);
 }
 
-function createRequire(rootPath, config, parent) {
+function createRequire(config, parent) {
     const requireFactory = (base) => {
         return (target) => {
             // eslint-disable-next-line global-require
@@ -101,7 +99,7 @@ function createRequire(rootPath, config, parent) {
     parent.requireLib = requireFactory(config.lib);
 }
 
-function createReload(rootPath, config, parent) {
+function createReload(config, parent) {
     const reloadFactory = (base, requireFn) => {
         return (target) => {
             const filePath = require.resolve(path.join(base, target));

--- a/bootstrap/directories.js
+++ b/bootstrap/directories.js
@@ -70,7 +70,7 @@ function createRequire(config, parent) {
     const requireFactory = (base) => {
         return (target) => {
             // eslint-disable-next-line global-require
-            return require(path.join(base, target));
+            return require(path.resolve(base, target));
         };
     };
 

--- a/bootstrap/system-config.js
+++ b/bootstrap/system-config.js
@@ -24,7 +24,7 @@ const SystemConfig    = deepmerge.all([
 ]);
 
 const rootDir = path.dirname(require.resolve('regent'));
-Directories.configure(rootDir, SystemConfig.Directories);
+Directories.configure(SystemConfig.Directories);
 
 module.exports = {
     DefaultConfig,

--- a/index.js
+++ b/index.js
@@ -30,10 +30,10 @@ function create(appDir = rootDir, LocalConfig = {}) {
         LocalConfig,
     ]);
 
-    directories.configure(rootDir, SystemConfig.Directories);
+    directories.configure(SystemConfig.Directories);
 
     const AppConfig    = directories.requireApp(SystemConfig.AppConfig.file);
-    return new Regent(rootDir, SystemConfig, AppConfig);
+    return new Regent(SystemConfig, AppConfig);
 }
 
 // Configure and start Regent as a dependency

--- a/index.js
+++ b/index.js
@@ -13,14 +13,15 @@ const directories   = require('regent/bootstrap/directories');
 const DefaultConfig = require('regent/etc/default');
 const Regent        = require('regent/lib/core/regent');
 const deepmerge     = require('deepmerge');
+const { resolve }   = require('path');
 const rootDir       = __dirname;
 
 // Configure (but do not start) a Regent instance
 function create(appDir = rootDir, LocalConfig = {}) {
     const interimConfig = {
         Directories: {
-            app: `${appDir}/app`,
-            log: `${appDir}/storage/log`,
+            app: resolve(`${appDir}/app`),
+            log: resolve(`${appDir}/storage/log`),
         },
     };
     const SystemConfig = deepmerge.all([

--- a/lib/core/regent.js
+++ b/lib/core/regent.js
@@ -203,6 +203,12 @@ function prepareEmitter() {
         this.getLogger().error(`Uncaught Exception: ${event.stack}`);
     });
 
+    process.on('warning', (warning) => {
+        this.getEmitter()
+            .emit(Events.UNCAUGHT_WARNING, warning);
+        this.getLogger().warn(`${warning.stack}`);
+    });
+
     return this;
 }
 

--- a/lib/core/regent.js
+++ b/lib/core/regent.js
@@ -37,7 +37,7 @@ const HTTP         = 'http';
  * @class
  */
 class Regent extends BaseObject {
-    constructor(rootDir, sysConfig, appConfig) {
+    constructor(sysConfig, appConfig) {
         super();
 
         /**
@@ -98,7 +98,6 @@ class Regent extends BaseObject {
             emitter,
             kernels,
             logger,
-            rootDir,
             routers,
             templater,
         });

--- a/lib/file/file-system.js
+++ b/lib/file/file-system.js
@@ -35,8 +35,12 @@ class FileSystem extends RegentObject {
         if (!this.call(checkExists, fileName)) {
             return false;
         }
-        const stat = await this.call(getStat, fileName);
-        return stat.isFile();
+        try {
+            const stat = await this.call(getStat, fileName);
+            return stat.isFile();
+        } catch (error) {
+            return false;
+        }
     }
 
     /**
@@ -50,8 +54,12 @@ class FileSystem extends RegentObject {
         if (!this.call(checkExists, dirName)) {
             return false;
         }
-        const stat = await this.call(getStat, dirName);
-        return stat.isDirectory();
+        try {
+            const stat = await this.call(getStat, dirName);
+            return stat.isDirectory();
+        } catch (error) {
+            return false;
+        }
     }
 
     /**

--- a/lib/util/regent-emitter.js
+++ b/lib/util/regent-emitter.js
@@ -26,8 +26,10 @@ class RegentEmitter extends RegentObject {
             generic,
         });
 
-        this.on('error', (err) => regent.getLogger().error(err.message));
-        this.on('warning', (warning) => {
+        this.on('error', (err = { message: 'generic error' }) => {
+            return regent.getLogger().error(err.message);
+        });
+        this.on('warning', (warning = { message: 'generic warning' }) => {
             return regent.getLogger().warn(warning.message);
         });
     }

--- a/lib/util/regent-emitter.js
+++ b/lib/util/regent-emitter.js
@@ -18,9 +18,33 @@ class RegentEmitter extends RegentObject {
     constructor(regent) {
         super(regent);
 
-        $private(this).emitter = new EventEmitter();
+        const generic = [];
+        const emitter = this.call(getEmitter, generic);
+
+        $private.set(this, {
+            emitter,
+            generic,
+        });
 
         this.on('error', (err) => regent.getLogger().error(err.message));
+        this.on('warning', (warning) => {
+            return regent.getLogger().warn(warning.message);
+        });
+    }
+
+    /**
+     * Adds a generic event-listener that triggers on any event
+     *
+     * @method any
+     *
+     * @param {Function} listener
+     *
+     * @return {this}
+     */
+    onAny(listener) {
+        const { generic } = $private(this);
+        generic.push(listener);
+        return this;
     }
 
     /**
@@ -72,7 +96,7 @@ class RegentEmitter extends RegentObject {
      * @param {...mixed} args      - The list of arguments to send to the
      *                               event listeners
      *
-     * @return {Boolean} Returns `true` if the event hand listeners,
+     * @return {Boolean} Returns `true` if the event had listeners,
      *                   `false` otherwise.
      */
     emit(eventName, ...args) {
@@ -88,20 +112,15 @@ class RegentEmitter extends RegentObject {
     eventNames() {
         return $private(this).emitter.eventNames();
     }
+}
 
-    /**
-     * This function attaches the RegentEmitter to the given to the target
-     * object. Once attached, this emitter can be retrieved using a newly
-     * attached method, getEmitter();
-     *
-     * @param {Object} target
-     *
-     * @return {this}
-     */
-    attachTo(target) {
-        target.getEmitter = () => this;
-        return this;
-    }
+function getEmitter(generic) {
+    const emitter = new EventEmitter();
+    emitter.emit  = function(eventName, ...args) {
+        generic.forEach((listener) => listener.call(this, eventName, ...args));
+        return EventEmitter.prototype.emit.call(this, eventName, ...args);
+    };
+    return emitter;
 }
 
 module.exports = RegentEmitter;

--- a/test/integration/index.js
+++ b/test/integration/index.js
@@ -1,0 +1,31 @@
+/**
+ * @author Steven Jimenez <steven@stevethedev.com>
+ */
+'use strict';
+
+const assert = require('regent/lib/util/assert');
+const Regent = require('regent/lib/core/regent');
+const { dirname } = require('path');
+const { create, start } = require('regent');
+
+const rootDir = dirname(require.resolve('regent'));
+
+describe('The require("regent") response', () => {
+    describe('create method', () => {
+        it('should return a Regent instance', () => {
+            assert.instanceOf(create(rootDir), Regent);
+        });
+    });
+    describe('start method', () => {
+        it('should call the Regent::start method', () => {
+            const oldStart = Regent.prototype.start;
+            let executed = true;
+            Regent.prototype.start = () => {
+                executed = true;
+            };
+            start(rootDir);
+            Regent.prototype.start = oldStart;
+            assert.isTrue(executed);
+        });
+    });
+});

--- a/test/test.js
+++ b/test/test.js
@@ -11,7 +11,7 @@ const Mocha = require('mocha');
 const fs    = require('fs');
 const path  = require('path');
 
-const { rootDir, SystemConfig } = require('../bootstrap/system-config');
+const { SystemConfig } = require('../bootstrap/system-config');
 
 const AppConfig = require('regent/app/app');
 const Regent    = require('regent/lib/core/regent');
@@ -20,7 +20,7 @@ const LAST_THREE = -3;
 // Prevent the system from complaining about max-listeners
 process.setMaxListeners(Infinity);
 
-global.newRegent = () => new Regent(rootDir, SystemConfig, AppConfig);
+global.newRegent = () => new Regent(SystemConfig, AppConfig);
 
 function readdir(directory, mocha) {
     fs.readdirSync(directory).forEach((file) => {

--- a/test/test.js
+++ b/test/test.js
@@ -17,6 +17,9 @@ const AppConfig = require('regent/app/app');
 const Regent    = require('regent/lib/core/regent');
 const LAST_THREE = -3;
 
+// Prevent the system from complaining about max-listeners
+process.setMaxListeners(Infinity);
+
 global.newRegent = () => new Regent(rootDir, SystemConfig, AppConfig);
 
 function readdir(directory, mocha) {

--- a/test/unit/lib/core/regent.js
+++ b/test/unit/lib/core/regent.js
@@ -1,0 +1,176 @@
+/**
+ * @author Steven Jimenez <steven@stevethedev.com>
+ */
+'use strict';
+
+const assert = require('regent/lib/util/assert');
+const Regent = require('regent/lib/core/regent');
+
+const RegentEmitter = require('regent/lib/util/regent-emitter');
+const HttpKernel    = require('regent/lib/http/kernel');
+const HttpRouter    = require('regent/lib/http/routing/router');
+const RegentLogger  = require('regent/lib/log/logger');
+const NunjucksMgr   = require('regent/lib/http/view/nunjucks-manager');
+
+const KERNEL_TYPES  = ['http'];
+const ROUTER_TYPES  = ['http'];
+
+const { SystemConfig } = require('regent/bootstrap/system-config');
+
+const { newRegent } = global;
+
+const CLASS_NAME   = Regent.name;
+
+describe(`The ${CLASS_NAME} class`, () => {
+    describe('constructor', () => {
+        describe('(<sysConfig>, <appConfig>) signature', () => {
+            const regent = new Regent(SystemConfig, {});
+            it('should create a new instance', () => {
+                assert.instanceOf(regent, Regent);
+            });
+            it('should register "uncaughtException" events', () => {
+                assert.isTrue(
+                    process.eventNames().includes('uncaughtException')
+                );
+            });
+            it('should register "unhandledRejection" events', () => {
+                assert.isTrue(
+                    process.eventNames().includes('unhandledRejection')
+                );
+            });
+            it('should register "warning" events', () => {
+                assert.isTrue(process.eventNames().includes('warning'));
+            });
+        });
+    });
+    describe('start method', () => {
+        const regent = newRegent();
+        KERNEL_TYPES.forEach((kernelType) => {
+            const kernel = regent.getKernel(kernelType);
+            kernel.start = () => false;
+        });
+        ROUTER_TYPES.forEach((routerType) => {
+            const router = regent.getRouter(routerType);
+            router.load = () => false;
+        });
+        describe('() signature', () => {
+            KERNEL_TYPES.forEach((kernelType) => {
+                it(`should start the '${kernelType}' kernel`, () => {
+                    let executed = false;
+                    const kernel = regent.getKernel(kernelType);
+                    kernel.start = () => {
+                        executed = true;
+                    };
+                    regent.start();
+                    assert.isTrue(executed);
+                });
+            });
+            ROUTER_TYPES.forEach((routerType) => {
+                it(`should load the '${routerType}' router`, () => {
+                    let executed = false;
+                    const router = regent.getRouter(routerType);
+                    router.load = () => {
+                        executed = true;
+                    };
+                    regent.start();
+                    assert.isTrue(executed);
+                });
+            });
+            it('should return the instance', () => {
+                assert.equal(regent.start(), regent);
+            });
+        });
+    });
+    describe('stop method', () => {
+        const regent = newRegent();
+        KERNEL_TYPES.forEach((kernelType) => {
+            const kernel = regent.getKernel(kernelType);
+            kernel.stop = () => false;
+        });
+        ROUTER_TYPES.forEach((routerType) => {
+            const router = regent.getRouter(routerType);
+            router.unload = () => false;
+        });
+        describe('() signature', () => {
+            KERNEL_TYPES.forEach((kernelType) => {
+                it(`should stop the '${kernelType}' kernel`, () => {
+                    let executed = false;
+                    const kernel = regent.getKernel(kernelType);
+                    kernel.stop = () => {
+                        executed = true;
+                    };
+                    regent.stop();
+                    assert.isTrue(executed);
+                });
+            });
+            ROUTER_TYPES.forEach((routerType) => {
+                it(`should stop the '${routerType}' router`, () => {
+                    let executed = false;
+                    const router = regent.getRouter(routerType);
+                    router.unload = () => {
+                        executed = true;
+                    };
+                    regent.stop();
+                    assert.isTrue(executed);
+                });
+            });
+            it('should return the instance', () => {
+                assert.equal(regent.stop(), regent);
+            });
+        });
+    });
+    describe('getKernel method', () => {
+        const regent = newRegent();
+        KERNEL_TYPES.forEach((kernelType) => {
+            describe(`('${kernelType}') signature`, () => {
+                it('should return the HttpKernel', () => {
+                    assert.instanceOf(regent.getKernel('http'), HttpKernel);
+                });
+            });
+        });
+        describe('(<type>) signature', () => {
+            it('should return null', () => {
+                assert.isNull(regent.getKernel('foo'));
+            });
+        });
+    });
+    describe('getRouter method', () => {
+        const regent = newRegent();
+        ROUTER_TYPES.forEach((routerType) => {
+            describe(`('${routerType}') signature`, () => {
+                it('should return the HttpRouter', () => {
+                    assert.instanceOf(regent.getRouter('http'), HttpRouter);
+                });
+            });
+        });
+        describe('(<type>) signature', () => {
+            it('should return null', () => {
+                assert.isNull(regent.getRouter('foo'));
+            });
+        });
+    });
+    describe('getLogger method', () => {
+        const regent = newRegent();
+        describe('() signature', () => {
+            it('should return the Logger', () => {
+                assert.instanceOf(regent.getLogger(), RegentLogger);
+            });
+        });
+    });
+    describe('getEmitter method', () => {
+        const regent = newRegent();
+        describe('() signature', () => {
+            it('should return the Emitter', () => {
+                assert.instanceOf(regent.getEmitter(), RegentEmitter);
+            });
+        });
+    });
+    describe('getTemplater method', () => {
+        const regent = newRegent();
+        describe('() signature', () => {
+            it('should return the Template Manager', () => {
+                assert.instanceOf(regent.getTemplater(), NunjucksMgr);
+            });
+        });
+    });
+});

--- a/test/unit/lib/util/regent-emitter.js
+++ b/test/unit/lib/util/regent-emitter.js
@@ -12,6 +12,29 @@ const EVENT        = 'foo';
 const regent       = global.newRegent();
 
 describe(`The ${CLASS_NAME} class`, () => {
+    describe('constructor', () => {
+        describe('(regent) signature', () => {
+            const emitter = new RegentEmitter(regent);
+            regent.getLogger().error = () => false;
+            regent.getLogger().warn  = () => false;
+            it('should register an "error" listener', () => {
+                let executed = false;
+                regent.getLogger().error = () => {
+                    executed = true;
+                };
+                emitter.emit('error');
+                assert.isTrue(executed);
+            });
+            it('should register a "warning" listener', () => {
+                let executed = false;
+                regent.getLogger().warn = () => {
+                    executed = true;
+                };
+                emitter.emit('warning');
+                assert.isTrue(executed);
+            });
+        });
+    });
     describe('onAny method', () => {
         const emitter = new RegentEmitter(regent);
         describe('(listener) signature', () => {

--- a/test/unit/lib/util/regent-emitter.js
+++ b/test/unit/lib/util/regent-emitter.js
@@ -1,0 +1,184 @@
+/**
+ * @author Steven Jimenez <steven@stevethedev.com>
+ */
+'use strict';
+
+const assert        = require('regent/lib/util/assert');
+const RegentEmitter = require('regent/lib/util/regent-emitter');
+
+const CLASS_NAME   = RegentEmitter.name;
+const EVENT        = 'foo';
+
+const regent       = global.newRegent();
+
+describe(`The ${CLASS_NAME} class`, () => {
+    describe('onAny method', () => {
+        const emitter = new RegentEmitter(regent);
+        describe('(listener) signature', () => {
+            it('should add a listener that triggers on any event', () => {
+                let executed = false;
+                emitter.onAny(() => {
+                    executed = true;
+                });
+                emitter.emit('foo');
+                assert.isTrue(executed);
+            });
+            it('should include the event name as the first argument', () => {
+                emitter.onAny((eventName) => assert.equal(eventName, EVENT));
+                emitter.emit(EVENT);
+            });
+            it('should include emitted values in the other arguments', () => {
+                const ARGS  = [ 0, 1 ];
+                emitter.onAny((eventName, ...args) => {
+                    ARGS.forEach((arg, i) => {
+                        assert.equal(args[i], arg);
+                    });
+                });
+                emitter.emit(EVENT, ...ARGS);
+            });
+            it('should return the emitter', () => {
+                assert.equal(emitter.onAny(() => true), emitter);
+            });
+        });
+    });
+    describe('on method', () => {
+        const emitter = new RegentEmitter(regent);
+        describe('(eventName, listener) signature', () => {
+            it('should add a listener to the given eventName', () => {
+                let executed = false;
+                emitter.on(EVENT, () => {
+                    executed = true;
+                });
+                emitter.emit(EVENT);
+                assert.isTrue(executed);
+            });
+            it('should return the emitter', () => {
+                assert.equal(emitter.on('foo', () => true), emitter);
+            });
+        });
+    });
+    describe('off method', () => {
+        const emitter = new RegentEmitter(regent);
+        describe('() signature', () => {
+            it('should remove all event listeners', () => {
+                let executed = false;
+                emitter.on(EVENT, () => {
+                    executed = true;
+                });
+                emitter.off();
+                emitter.emit(EVENT);
+                assert.isFalse(executed);
+            });
+            it('should return the emitter', () => {
+                assert.equal(emitter.off(), emitter);
+            });
+        });
+        describe('(eventName) signature', () => {
+            it('should remove all listeners for the eventName', () => {
+                let executed = false;
+                emitter.on(EVENT, () => {
+                    executed = true;
+                });
+                emitter.off(EVENT);
+                assert.isFalse(executed);
+            });
+            it('should not remove events that were not named', () => {
+                let executed = false;
+                emitter.on(EVENT, () => {
+                    executed = true;
+                });
+                emitter.off(`${EVENT}-`);
+                emitter.emit(EVENT);
+                assert.isTrue(executed);
+            });
+            it('should return the emitter', () => {
+                assert.equal(emitter.off('foo'), emitter);
+            });
+        });
+        describe('(eventName, listener) signature', () => {
+            it('should remove the given eventName/listener pair', () => {
+                let executed = false;
+                const LISTENER = () => {
+                    executed = true;
+                };
+
+                emitter.on(EVENT, LISTENER);
+                emitter.off(EVENT, LISTENER);
+                emitter.emit(EVENT);
+
+                assert.isFalse(executed);
+            });
+            it('should not remove events that were not named', () => {
+                let executed = false;
+                const LISTENER = () => {
+                    executed = true;
+                };
+
+                emitter.on(EVENT, LISTENER);
+                emitter.off(`${EVENT}-`, LISTENER);
+                emitter.emit(EVENT);
+
+                assert.isTrue(executed);
+            });
+            it('should not remove events that use different listeners', () => {
+                let executed = false;
+                const LISTENER = () => {
+                    executed = true;
+                };
+
+                emitter.on(EVENT, LISTENER);
+                emitter.off(EVENT, () => true);
+                emitter.emit(EVENT);
+
+                assert.isTrue(executed);
+            });
+            it('should return the emitter', () => {
+                assert.equal(emitter.off('foo', () => true), emitter);
+            });
+        });
+    });
+    describe('emit method', () => {
+        describe('(eventName, [...args]) signature', () => {
+            it('should trigger the eventName event', () => {
+                const emitter = new RegentEmitter(regent);
+                let executed = true;
+
+                emitter.on(EVENT, () => {
+                    executed = true;
+                });
+                emitter.emit(EVENT);
+
+                assert.isTrue(executed);
+            });
+            it('should emit the given arguments', () => {
+                const emitter = new RegentEmitter(regent);
+                const ARGS  = [ 0, 1 ];
+
+                emitter.on(EVENT, (...args) => {
+                    ARGS.forEach((arg, i) => {
+                        assert.equal(arg, args[i]);
+                    });
+                });
+
+                emitter.emit(EVENT, ...ARGS);
+            });
+            it('should return true if the event had listeners', () => {
+                const emitter = new RegentEmitter(regent);
+                emitter.on(EVENT, () => true);
+                assert.isTrue(emitter.emit(EVENT));
+            });
+            it('should return false if the event had no listeners', () => {
+                const emitter = new RegentEmitter(regent);
+                assert.isFalse(emitter.emit(`${EVENT}-`));
+            });
+        });
+    });
+    describe('eventNames method', () => {
+        const emitter = new RegentEmitter(regent);
+        it('should return an array of the registered event names', () => {
+            emitter.on(EVENT, () => true);
+            const eventNames = emitter.eventNames();
+            assert.isTrue(eventNames.includes(EVENT));
+        });
+    });
+});


### PR DESCRIPTION
### Proposed changes

This updates the RegentEmitter class with the ability to listen to any event.

### Types of changes

Put an `x` in the boxes that describe the kind of change you are making.

- [ ] Bug-Fix (I am introducing a non-breaking change which fixes an issue).
- [x] New feature (I am introducing a non-breaking change which adds
      functionality).
- [x] Breaking change (I am introducing a fix or feature that would cause
      existing functionality to not work as expected).

### Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating
the Pull Request. This is just a reminder of the things that will be checked
before your code is merged in.

- [x] I have read the [CONTRIBUTING] doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my
      feature works
- [x] I have added necessary documentation (if appropriate)

### Comments

This update breaks the core Regent interface. Regent no longer takes a string path as the first parameter.

[CONTRIBUTING]: https://github.com/stevethedev/regent/blob/master/CONTRIBUTING.md
[Pull Requests]: https://github.com/stevethedev/regent/pulls

  