### PR TITLE
Regent 16

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,34 +9,38 @@
 
 const DefaultConfig = require('regent-js/etc/default');
 const Regent        = require('regent-js/lib/core/regent');
-const deepmerge     = require('deepmerge');
+const ObjectMerger  = require('regent-js/lib/util/object-merger');
 const { resolve }   = require('path');
+const inlineRequire = require;
 const rootDir       = __dirname;
 
 // Configure (but do not start) a Regent instance
-function create(appDir = rootDir, SystemConfig = {}, AppConfig = {}) {
+function create(appDir = rootDir, SystemConfig = {}, AppConfig = null) {
+    const merger = new ObjectMerger();
     const interimConfig = {
         Directories: {
             app: resolve(`${appDir}/app`),
             log: resolve(`${appDir}/storage/log`),
         },
     };
-    SystemConfig = deepmerge.all([
+    SystemConfig = merger.merge(
         {},
         DefaultConfig,
         interimConfig,
         SystemConfig,
-    ], {
-        arrayMerge(destination, source) {
-            return source;
-        },
-    });
+    );
+
+    if (!AppConfig) {
+        AppConfig = (SystemConfig.AppConfig && SystemConfig.AppConfig.file)
+            ? AppConfig = inlineRequire(SystemConfig.AppConfig.file)
+            : SystemConfig.AppConfig || {};
+    }
 
     return new Regent(SystemConfig, AppConfig);
 }
 
 // Configure and start Regent as a dependency
-function start(appDir = rootDir, SystemConfig = {}, LocalConfig = {}) {
+function start(appDir = rootDir, SystemConfig = {}, LocalConfig = null) {
     return create(appDir, SystemConfig, LocalConfig).start();
 }
 

--- a/lib/http/middleware/csrf.js
+++ b/lib/http/middleware/csrf.js
@@ -188,7 +188,7 @@ async function protectRequest(request, response) {
             || await request.getBody(CSRF_FIELD));
     }
 
-    if (token !== request.getSession().get(CSRF_FIELD)) {
+    if (!(token && token === request.getSession().get(CSRF_FIELD))) {
         const message = 'CSRF Token Mismatch';
         const error = new Error('CSRF Token Mismatch');
         const event = new ForbiddenError(this.getRegent(), {

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -87,15 +87,16 @@ class HttpRequest extends RequestResponse {
      * Retrieve the HTTP Header from the request object.
      *
      * @param {String} name
+     * @param {Mixed}  [fallback]
      *
      * @return {String}
      */
-    getHeader(name) {
+    getHeader(name, fallback = null) {
         const headers = $private(this).httpRequest.headers || {};
         if (Object.prototype.hasOwnProperty.call(headers, name)) {
             return headers[name];
         }
-        return null;
+        return fallback;
     }
 
     /**
@@ -118,14 +119,18 @@ class HttpRequest extends RequestResponse {
      * @async
      * @method getBody
      *
-     * @param {String} field
+     * @param {String} [field]
+     * @param {Mixed}  [fallback]
      *
      * @return {String}
      */
-    async getBody(field = null) {
+    async getBody(field = null, fallback = null) {
         const fields = await this.getBodyParser().getAuto();
         if (field) {
-            return fields[field];
+            if (Object.prototype.hasOwnProperty.call(fields, field)) {
+                return fields[field];
+            }
+            return fallback;
         }
         return fields;
     }

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -173,7 +173,7 @@ class HttpRequest extends RequestResponse {
      *
      * @return {Mixed}
      */
-    async getInput(key = null, fallback = null) {
+    async getInput(key, fallback = null) {
         return this.getParam(key, await this.getBody(key, fallback));
     }
 }

--- a/lib/http/request.js
+++ b/lib/http/request.js
@@ -6,6 +6,7 @@
 const BodyParser               = require('regent-js/lib/http/parser');
 const FileSystem               = require('regent-js/lib/file/file-system');
 const RequestResponse          = require('regent-js/lib/core/request-response');
+const url                      = require('url');
 const { $private, $protected } = require('regent-js/lib/util/scope').create();
 
 const CONTENT_TYPE = 'content-type';
@@ -93,10 +94,9 @@ class HttpRequest extends RequestResponse {
      */
     getHeader(name, fallback = null) {
         const headers = $private(this).httpRequest.headers || {};
-        if (Object.prototype.hasOwnProperty.call(headers, name)) {
-            return headers[name];
-        }
-        return fallback;
+        return Object.prototype.hasOwnProperty.call(headers, name)
+            ? headers[name]
+            : fallback;
     }
 
     /**
@@ -107,10 +107,7 @@ class HttpRequest extends RequestResponse {
      */
     getUri() {
         const { httpRequest } = $private(this);
-        if (!httpRequest || !httpRequest.url) {
-            return '';
-        }
-        return httpRequest.url;
+        return ((httpRequest && httpRequest.url) || '').split('?')[0];
     }
 
     /**
@@ -127,10 +124,9 @@ class HttpRequest extends RequestResponse {
     async getBody(field = null, fallback = null) {
         const fields = await this.getBodyParser().getAuto();
         if (field) {
-            if (Object.prototype.hasOwnProperty.call(fields, field)) {
-                return fields[field];
-            }
-            return fallback;
+            return Object.prototype.hasOwnProperty.call(fields, field)
+                ? fields[field]
+                : fallback;
         }
         return fields;
     }
@@ -144,6 +140,41 @@ class HttpRequest extends RequestResponse {
      */
     getBodyParser() {
         return $private(this).bodyParser;
+    }
+
+    /**
+     * Get Query String parameters
+     *
+     * @method getParam
+     *
+     * @param  {String} [key]
+     * @param  {Mixed}  [fallback]
+     *
+     * @return {Mixed}
+     */
+    getParam(key = null, fallback = null) {
+        const { httpRequest } = $private(this);
+        const params = url.parse(httpRequest.url, true).query;
+        if (null !== key) {
+            return Object.prototype.hasOwnProperty.call(params, key)
+                ? params[key]
+                : fallback;
+        }
+        return params;
+    }
+
+    /**
+     * Get input from the query-string or HTTP body
+     *
+     * @method getInput
+     *
+     * @param {String} [key]
+     * @param {Mixed}  [fallback]
+     *
+     * @return {Mixed}
+     */
+    async getInput(key = null, fallback = null) {
+        return this.getParam(key, await this.getBody(key, fallback));
     }
 }
 

--- a/test/unit/lib/http/request.js
+++ b/test/unit/lib/http/request.js
@@ -126,11 +126,11 @@ describe(`The ${CLASS_NAME} class`, () => {
         describe('(<field>) signature', () => {
             const test = runBefore({
                 body: JSON.stringify({ foo: 'bar' }),
-                contentType: 'application/json',
                 async callback() {
                     test.promise = test.request.getBody('foo');
                     test.result = await test.promise;
                 },
+                contentType: 'application/json',
             });
             it('should return a Promise', () => {
                 assert.isPromise(test.promise);
@@ -148,11 +148,11 @@ describe(`The ${CLASS_NAME} class`, () => {
         describe('(<field>, <default>) signature', () => {
             const test = runBefore({
                 body: JSON.stringify({ foo: 'bar' }),
-                contentType: 'application/json',
                 async callback() {
                     test.promise = test.request.getBody('foo', 'baz');
                     test.result = await test.promise;
                 },
+                contentType: 'application/json',
             });
             it('should return a Promise', () => {
                 assert.isPromise(test.promise);
@@ -178,6 +178,140 @@ describe(`The ${CLASS_NAME} class`, () => {
             it('should return a BodyParser', () => {
                 assert.instanceOf(test.request.getBodyParser(), BodyParser);
             });
+        });
+    });
+    describe('getParam method', () => {
+        describe('() signature', () => {
+            const test = runBefore({
+                callback() {
+                    test.query = 'foo=bar&baz=gab';
+                    test.clientRequest.url = `/?${test.query}`;
+                    test.result = test.request.getParam();
+                },
+            });
+            it('should return all of the query parameters', () => {
+                assert.isObject(test.result);
+                assert.equal(test.result.foo, 'bar');
+                assert.equal(test.result.baz, 'gab');
+            });
+        });
+        describe('(<key>) signature', () => {
+            const test = runBefore({
+                callback() {
+                    test.query = 'foo=bar&baz=gab';
+                    test.clientRequest.url = `/?${test.query}`;
+                },
+            });
+            it('should return the query parameter <key> if it exists', () => {
+                assert.equal(test.request.getParam('foo'), 'bar');
+            });
+            it('should return null if no parameter <key> exists', () => {
+                assert.isNull(test.request.getParam('hello'));
+            });
+        });
+        describe('(<key>, <fallback>) signature', () => {
+            const test = runBefore({
+                callback() {
+                    test.query = 'foo=bar&baz=gab';
+                    test.clientRequest.url = `/?${test.query}`;
+                    test.result = test.request.getParam('foo', null);
+                },
+            });
+            it('should return the query parameter <key> if it exists', () => {
+                assert.equal(test.request.getParam('foo', 'hello'), 'bar');
+            });
+            it('should return <fallback> if no parameter <key> exists', () => {
+                assert.equal(test.request.getParam('hello', 'world'), 'world');
+            });
+        });
+    });
+    describe('getInput method', () => {
+        describe('(<key>) signature', () => {
+            const test = runBefore({
+                body: JSON.stringify({
+                    bar: 'bar',
+                    foo: 'foo',
+                }),
+                async callback() {
+                    test.query = 'foo=FOO';
+                    test.clientRequest.url = `/?${test.query}`;
+                    test.promise = {
+                        bar: test.request.getInput('bar'),
+                        baz: test.request.getInput('baz'),
+                        foo: test.request.getInput('foo'),
+                    };
+                    test.result = {
+                        bar: await test.promise.bar,
+                        baz: await test.promise.baz,
+                        foo: await test.promise.foo,
+                    };
+                },
+                contentType: 'application/json',
+            });
+            it('should return a Promise', () => {
+                assert.isPromise(test.promise.foo);
+                assert.isPromise(test.promise.bar);
+                assert.isPromise(test.promise.baz);
+            });
+            it('should resolve to <key> if it is in the query', () => {
+                assert.equal(test.result.foo, 'FOO');
+            });
+            it(
+                'should resolve to <key> in the body if it is not in the query',
+                () => {
+                    assert.equal(test.result.bar, 'bar');
+                }
+            );
+            it(
+                'should resolve to null if <key> is not in the query or body',
+                () => {
+                    assert.equal(test.result.baz, null);
+                }
+            );
+        });
+        describe('(<key>, <fallback>) signature', () => {
+            const test = runBefore({
+                body: JSON.stringify({
+                    bar: 'bar',
+                    foo: 'foo',
+                }),
+                async callback() {
+                    test.query = 'foo=FOO';
+                    test.clientRequest.url = `/?${test.query}`;
+                    test.promise = {
+                        bar: test.request.getInput('bar', 'hello'),
+                        baz: test.request.getInput('baz', 'hello'),
+                        foo: test.request.getInput('foo', 'hello'),
+                    };
+                    test.result = {
+                        bar: await test.promise.bar,
+                        baz: await test.promise.baz,
+                        foo: await test.promise.foo,
+                    };
+                },
+                contentType: 'application/json',
+            });
+            it('should return a Promise', () => {
+                assert.isPromise(test.promise.foo);
+                assert.isPromise(test.promise.bar);
+                assert.isPromise(test.promise.baz);
+            });
+            it('should resolve to <key> if it is in the query', () => {
+                assert.equal(test.result.foo, 'FOO');
+            });
+            it(
+                'should resolve to <key> in the body if it is not in the query',
+                () => {
+                    assert.equal(test.result.bar, 'bar');
+                }
+            );
+            it(
+                'should resolve to <fallback> if <key> is not in the query '
+                    + 'or body',
+                () => {
+                    assert.equal(test.result.baz, 'hello');
+                }
+            );
         });
     });
 });

--- a/test/unit/lib/http/request.js
+++ b/test/unit/lib/http/request.js
@@ -1,0 +1,183 @@
+/**
+ * @author Steven Jimenez <steven@stevethedev.com>
+ */
+'use strict';
+
+const assert      = require('regent-js/lib/util/assert');
+const BodyParser  = require('regent-js/lib/http/parser');
+const HttpRequest = require('regent-js/lib/http/request');
+const HttpKernel  = require('regent-js/lib/http/kernel');
+const regent = global.newRegent();
+const kernel = new HttpKernel(regent);
+
+const { IncomingMessage } = require('http');
+
+const CLASS_NAME = HttpRequest.name;
+
+const runBefore = ({ body, contentType, callback = () => true } = {}) => {
+    const test = { body };
+    const setup = () => {
+        test.clientRequest = new IncomingMessage();
+        if (contentType) {
+            test.clientRequest.headers['content-type'] = contentType;
+        }
+        test.clientRequest.method = 'GET';
+        test.request = new HttpRequest(kernel, test.clientRequest, body);
+        return callback();
+    };
+    before(setup);
+    return test;
+};
+
+describe(`The ${CLASS_NAME} class`, () => {
+    describe('constructor', () => {
+        describe('(<httpKernel>, <httpRequest>, <httpBody>) signature', () => {
+            it(`should return a ${CLASS_NAME}`, () => {
+                assert.instanceOf(
+                    new HttpRequest(kernel, {}, ''),
+                    HttpRequest
+                );
+            });
+        });
+        describe('(<httpKernel>, <httpRequest>) signature', () => {
+            it(`should return a ${CLASS_NAME}`, () => {
+                assert.instanceOf(
+                    new HttpRequest(kernel, {}),
+                    HttpRequest
+                );
+            });
+            it('should initialize the body to a blank string', () => {
+                const request = new HttpRequest(kernel, {}, '');
+                assert.equal(request.getBodyParser().getText(), '');
+            });
+        });
+    });
+    describe('getMethod method', () => {
+        describe('() signature', () => {
+            const test = runBefore();
+            it('should return the HTTP Method', () => {
+                assert.equal(
+                    test.request.getMethod(),
+                    test.clientRequest.method
+                );
+            });
+        });
+    });
+    describe('getHeader method', () => {
+        describe('(<name>) signature', () => {
+            const test = runBefore();
+            it('should return the <header>', () => {
+                const { headers } = test.clientRequest;
+                for (const [ key, value ] of Object.entries(headers)) {
+                    assert.equal(test.request.getHeader(key), value);
+                }
+            });
+            it('should return <null> if <header> does not exist', () => {
+                const { headers } = test.clientRequest;
+                for (const [key] of Object.entries(headers)) {
+                    assert.isNull(test.request.getHeader(`${key}-`));
+                }
+            });
+        });
+        describe('(<name>, <default>) signature', () => {
+            const test = runBefore();
+            it('should return the <header>', () => {
+                const { headers } = test.clientRequest;
+                for (const [ key, value ] of Object.entries(headers)) {
+                    assert.equal(test.request.getHeader(key, 'foo'), value);
+                }
+            });
+            it('should return <default> if <header> does not exist', () => {
+                const { headers } = test.clientRequest;
+                for (const [key] of Object.entries(headers)) {
+                    assert.equal(test.request.getHeader(`${key}-`, 'f'), 'f');
+                }
+            });
+        });
+    });
+    describe('getUri method', () => {
+        describe('() signature', () => {
+            const test = runBefore();
+            it('should return an empty string if no URI is provided', () => {
+                assert.equal(test.request.getUri(), '');
+            });
+            it('should return the URI', () => {
+                test.clientRequest.url = 'foo';
+                assert.equal(test.request.getUri(), test.clientRequest.url);
+            });
+        });
+    });
+    describe('getBody method', () => {
+        describe('() signature', () => {
+            const test = runBefore({
+                body: 'foobar',
+                async callback() {
+                    test.promise = test.request.getBody();
+                    test.result = await test.promise;
+                },
+            });
+            it('should return a Promise', () => {
+                assert.isPromise(test.promise);
+            });
+            it('should resolve to the body content', () => {
+                assert.equal(test.result, test.body);
+            });
+        });
+        describe('(<field>) signature', () => {
+            const test = runBefore({
+                body: JSON.stringify({ foo: 'bar' }),
+                contentType: 'application/json',
+                async callback() {
+                    test.promise = test.request.getBody('foo');
+                    test.result = await test.promise;
+                },
+            });
+            it('should return a Promise', () => {
+                assert.isPromise(test.promise);
+            });
+            it('should resolve to the <field> value', () => {
+                assert.equal(test.result, JSON.parse(test.body).foo);
+            });
+            it(
+                'should resolve to null if the <field> value is not present',
+                async () => {
+                    assert.isNull(await test.request.getBody('bar'));
+                }
+            );
+        });
+        describe('(<field>, <default>) signature', () => {
+            const test = runBefore({
+                body: JSON.stringify({ foo: 'bar' }),
+                contentType: 'application/json',
+                async callback() {
+                    test.promise = test.request.getBody('foo', 'baz');
+                    test.result = await test.promise;
+                },
+            });
+            it('should return a Promise', () => {
+                assert.isPromise(test.promise);
+            });
+            it('should resolve to the <field> value', () => {
+                assert.equal(test.result, JSON.parse(test.body).foo);
+            });
+            it(
+                'should resolve to <default> if the <field> value is '
+                    + 'not present',
+                async () => {
+                    assert.equal(
+                        await test.request.getBody('bar', 'baz'),
+                        'baz'
+                    );
+                }
+            );
+        });
+    });
+    describe('getBodyParser method', () => {
+        describe('() signature', () => {
+            const test = runBefore();
+            it('should return a BodyParser', () => {
+                assert.instanceOf(test.request.getBodyParser(), BodyParser);
+            });
+        });
+    });
+});


### PR DESCRIPTION
### Proposed changes

Add ```getParam``` and ```getInput``` methods to HTTP Request objects.


### Linked Issues

#16 


### Types of changes

Put an `x` in the boxes that describe the kind of change you are making.

- [ ] Bug-Fix (I am introducing a non-breaking change which fixes an issue).
- [x] New feature (I am introducing a non-breaking change which adds
      functionality).
- [ ] Breaking change (I am introducing a fix or feature that would cause
      existing functionality to not work as expected).


### Checklist

Put an `x` in the boxes that apply. You can also fill these out after creating
the Pull Request. This is just a reminder of the things that will be checked
before your code is merged in.

- [x] I have read the [CONTRIBUTING] doc
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my
      feature works
- [x] I have added necessary documentation (if appropriate)


[CONTRIBUTING]: https://github.com/stevethedev/regent/blob/master/CONTRIBUTING.md
[Pull Requests]: https://github.com/stevethedev/regent/pulls
